### PR TITLE
Feat/member api

### DIFF
--- a/src/main/java/org/poolc/api/member/configurations/MemberDataLoader.java
+++ b/src/main/java/org/poolc/api/member/configurations/MemberDataLoader.java
@@ -106,6 +106,23 @@ public class MemberDataLoader implements CommandLineRunner {
                         null,
                         false,
                         null));
+        memberRepository.save(
+                new Member(UUID.randomUUID().toString(),
+                        "NOT_ADMIN_ID",
+                        passwordHashProvider.encodePassword("NOT_ADMIN_PASSWORD"),
+                        "example6@email.com",
+                        "examplePhoneNumber6",
+                        "MEMBER_NAME6",
+                        "exampleDepartment",
+                        "exampleStudentID6",
+                        true,
+                        false,
+                        null,
+                        null,
+                        null,
+                        null,
+                        false,
+                        null));
     }
 
 }

--- a/src/main/java/org/poolc/api/member/controller/MemberController.java
+++ b/src/main/java/org/poolc/api/member/controller/MemberController.java
@@ -33,7 +33,7 @@ public class MemberController {
     public ResponseEntity<MemberListResponse> getAllMembers(HttpServletRequest request) {
         checkAdmin(request);
 
-        Member member = memberService.findMember(request.getAttribute("UUID").toString());
+        Member member = memberService.findMemberbyUUID(request.getAttribute("UUID").toString());
 
         List<MemberResponse> memberList = memberService.getAllMembers()
                 .stream().map(m -> new MemberResponse(member))
@@ -51,10 +51,9 @@ public class MemberController {
         return ResponseEntity.accepted().build();
     }
 
-
     @GetMapping(value = "/me", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<MemberResponse> getMember(HttpServletRequest request) {
-        Member member = memberService.findMember(request.getAttribute("UUID").toString());
+        Member member = memberService.findMemberbyUUID(request.getAttribute("UUID").toString());
 
         return ResponseEntity.ok()
                 .body(new MemberResponse(member));
@@ -67,6 +66,15 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
+    @GetMapping(value = "/{loginID}")
+    public ResponseEntity<MemberResponse> adminGetMemberInfoByloginID(HttpServletRequest request, @PathVariable("loginID") String loginID) {
+        checkAdmin(request);
+
+        Member member = memberService.findMemberbyLoginID(loginID);
+
+        return ResponseEntity.ok().body(new MemberResponse(member));
+    }
+
     @DeleteMapping(value = "/{loginID}")
     public ResponseEntity deleteMember(HttpServletRequest request, @PathVariable("loginID") String loginID) {
         checkAdmin(request);
@@ -75,6 +83,25 @@ public class MemberController {
 
         return ResponseEntity.ok().build();
     }
+
+    @PutMapping(path = "/activate/{loginID}")
+    public ResponseEntity ActivateMember(HttpServletRequest request, @PathVariable("loginID") String loginID) {
+        checkAdmin(request);
+
+        memberService.authorizeMember(loginID);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping(path = "/admin/{loginID}")
+    public ResponseEntity updateMemberAdmin(HttpServletRequest request, @PathVariable("loginID") String loginID, @RequestBody Boolean isAdmin) {
+        checkAdmin(request);
+
+        memberService.updateIsAdmin(loginID, isAdmin);
+
+        return ResponseEntity.ok().build();
+    }
+
 
     @ExceptionHandler(UnauthenticatedException.class)
     public ResponseEntity<String> unauthenticatedHandler(Exception e) {

--- a/src/main/java/org/poolc/api/member/domain/Member.java
+++ b/src/main/java/org/poolc/api/member/domain/Member.java
@@ -92,4 +92,12 @@ public class Member extends TimestampEntity {
         this.email = updateMemberRequest.getEmail();
         this.phoneNumber = updateMemberRequest.getPhoneNumber();
     }
+
+    public void authorizeMember() {
+        this.isActivated = true;
+    }
+
+    public void updateIsAdmin(Boolean isAdmin) {
+        this.isAdmin = isAdmin;
+    }
 }

--- a/src/main/java/org/poolc/api/member/dto/MemberResponse.java
+++ b/src/main/java/org/poolc/api/member/dto/MemberResponse.java
@@ -14,6 +14,8 @@ public class MemberResponse {
     private final String studentID;
     private final String profileImageURL;
     private final String introduction;
+    private final Boolean isActivated;
+    private final Boolean isAdmin;
 
 
     @JsonCreator
@@ -26,5 +28,7 @@ public class MemberResponse {
         this.studentID = member.getStudentID();
         this.profileImageURL = member.getProfileImageURL();
         this.introduction = member.getIntroduction();
+        this.isActivated = member.getIsActivated();
+        this.isAdmin = member.getIsAdmin();
     }
 }

--- a/src/main/java/org/poolc/api/member/service/MemberService.java
+++ b/src/main/java/org/poolc/api/member/service/MemberService.java
@@ -60,13 +60,30 @@ public class MemberService {
         memberRepository.flush();
     }
 
+    public void authorizeMember(String loginID) {
+        Member findMember = memberRepository.findByLoginID(loginID).get();
+        findMember.authorizeMember();
+        memberRepository.flush();
+    }
+
+    public void updateIsAdmin(String loginID, Boolean isAdmin) {
+        Member findMember = memberRepository.findByLoginID(loginID).get();
+        findMember.updateIsAdmin(isAdmin);
+        memberRepository.flush();
+    }
+
     public void deleteMember(String loginID) {
         memberRepository.delete(memberRepository.findByLoginID(loginID)
                 .orElseThrow(() -> new NoSuchElementException("No user found with given loginID")));
     }
 
-    public Member findMember(String UUID) {
+    public Member findMemberbyUUID(String UUID) {
         return memberRepository.findById(UUID)
+                .orElseThrow(() -> new NoSuchElementException("No user found with given UUID"));
+    }
+
+    public Member findMemberbyLoginID(String loginID) {
+        return memberRepository.findByLoginID(loginID)
                 .orElseThrow(() -> new NoSuchElementException("No user found with given UUID"));
     }
 


### PR DESCRIPTION
### 📕 Issue Number

Close #70


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역
api 명세(https://www.notion.so/APIs-74e414180ab44003b7fd6b02a37b7e8e)을 수정하면서 진행하고 있는데, 누락된 api가 있어서 추가 및 수정했습니다.

MemberResponse 도메인 수정

관리자 페이지 관련 2. 특정 회원 조회 3. 가입 승인 5. 관리자 임명 및 해임 api 추가




### 📘 작업 유형

-  신규 기능 추가
-  리펙토링
-  문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

<br/><br/>
